### PR TITLE
Date Navigation Bar

### DIFF
--- a/crush-it/src/Homepage/homepage.js
+++ b/crush-it/src/Homepage/homepage.js
@@ -1,6 +1,14 @@
 import React, {useLayoutEffect} from "react";
 import { useNavigate } from "react-router";
-import {Box, Heading, Card, Container, Table, Tbody, TableContainer, Tr, Td, VStack, HStack} from '@chakra-ui/react';
+import {Box, Heading, Card, Container, Table, Tbody, TableContainer, Tr, Td, VStack, HStack, Center, IconButton, Button, Text} from '@chakra-ui/react';
+import {
+    Menu,
+    MenuButton,
+    MenuList,
+    MenuItem,
+  } from '@chakra-ui/react'
+import {IoChevronBackCircleSharp, IoChevronForwardCircleSharp, IoChevronDownCircleOutline} from 'react-icons/io5'
+
 function Homepage(){
   const navigate = useNavigate();
   // const [username, setUsername] = useState(null)
@@ -19,11 +27,149 @@ function Homepage(){
 
     return (
       
-      <Box p={5} bg="#F5F7F9" height={"94%"}>
+        <Box p={5} bg="#F5F7F9" height={"94%"}>
+
+        <Center w={"93%"} bg="#6284FF26" p={3} ml={5}>
+        <IconButton
+            variant='outline'
+            colorScheme='blue'
+            color="#6284FF"
+            aria-label='previousMonth'
+            size='lg'
+            fontSize={'3xl'}
+            icon={<IoChevronBackCircleSharp />}
+        />
+        <Menu>
+        <MenuButton as={Button} variant='outline' colorScheme='blue' ml={1} mr={1} color="#6284FF" size='lg' fontSize={'3xl'} rightIcon={<IoChevronDownCircleOutline />}>
+            <Text color="black" p={2} mt={3}>Month</Text>
+        </MenuButton>
+        <MenuList maxH="220px" overflowY="auto" w="200px">
+            <MenuItem ml={5} fontSize={'lg'}>January</MenuItem>
+            <MenuItem ml={5} fontSize={'lg'}>February</MenuItem>
+            <MenuItem ml={5} fontSize={'lg'}>March</MenuItem>
+            <MenuItem ml={5} fontSize={'lg'}>April</MenuItem>
+            <MenuItem ml={5} fontSize={'lg'}>May</MenuItem>
+            <MenuItem ml={5} fontSize={'lg'}>June</MenuItem>
+            <MenuItem ml={5} fontSize={'lg'}>July</MenuItem>
+            <MenuItem ml={5} fontSize={'lg'}>August</MenuItem>
+            <MenuItem ml={5} fontSize={'lg'}>September</MenuItem>
+            <MenuItem ml={5} fontSize={'lg'}>October</MenuItem>
+            <MenuItem ml={5} fontSize={'lg'}>November</MenuItem>
+            <MenuItem ml={5} fontSize={'lg'}>December</MenuItem>
+        </MenuList>
+        </Menu>
+        <IconButton
+            variant='outline'
+            colorScheme='blue'
+            color="#6284FF"
+            aria-label='previousMonth'
+            size='lg'
+            fontSize={'3xl'}
+            icon={<IoChevronForwardCircleSharp />}
+        />
+
+        <IconButton
+            variant='outline'
+            colorScheme='blue'
+            color="#6284FF"
+            aria-label='previousMonth'
+            size='lg'
+            fontSize={'3xl'}
+            icon={<IoChevronBackCircleSharp />}
+            ml={5}
+        />
+        <Menu>
+        <MenuButton as={Button} variant='outline' colorScheme='blue' ml={1} mr={1} color="#6284FF" size='lg' fontSize={'3xl'} rightIcon={<IoChevronDownCircleOutline />}>
+            <Text color="black" p={2} mt={3}>Day</Text>
+        </MenuButton>
+        <MenuList>
+            <MenuItem>1</MenuItem>
+            <MenuItem>2</MenuItem>
+            <MenuItem>3</MenuItem>
+            <MenuItem>4</MenuItem>
+            <MenuItem>5</MenuItem>
+            <MenuItem>6</MenuItem>
+            <MenuItem>7</MenuItem>
+            <MenuItem>8</MenuItem>
+            <MenuItem>9</MenuItem>
+            <MenuItem>10</MenuItem>
+            <MenuItem>11</MenuItem>
+            <MenuItem>12</MenuItem>
+            <MenuItem>13</MenuItem>
+            <MenuItem>14</MenuItem>
+            <MenuItem>15</MenuItem>
+            <MenuItem>16</MenuItem>
+            <MenuItem>17</MenuItem>
+            <MenuItem>18</MenuItem>
+            <MenuItem>19</MenuItem>
+            <MenuItem>20</MenuItem>
+            <MenuItem>21</MenuItem>
+            <MenuItem>22</MenuItem>
+            <MenuItem>23</MenuItem>
+            <MenuItem>24</MenuItem>
+            <MenuItem>25</MenuItem>
+            <MenuItem>26</MenuItem>
+            <MenuItem>27</MenuItem>
+            <MenuItem>28</MenuItem>
+            <MenuItem>29</MenuItem>
+            <MenuItem>30</MenuItem>
+            <MenuItem>31</MenuItem>
+        </MenuList>
+        </Menu>
+        <IconButton
+            variant='outline'
+            colorScheme='blue'
+            color="#6284FF"
+            aria-label='previousMonth'
+            size='lg'
+            fontSize={'3xl'}
+            icon={<IoChevronForwardCircleSharp />}
+        />
+
+        <IconButton
+            variant='outline'
+            colorScheme='blue'
+            color="#6284FF"
+            aria-label='previousMonth'
+            size='lg'
+            fontSize={'3xl'}
+            icon={<IoChevronBackCircleSharp />}
+            ml={5}
+        />
+        <Menu>
+        <MenuButton as={Button} variant='outline' colorScheme='blue' ml={1} mr={1} color="#6284FF" size='lg' fontSize={'3xl'} rightIcon={<IoChevronDownCircleOutline />}>
+            <Text color="black" p={2} mt={3}>Year</Text>
+        </MenuButton>
+        <MenuList>
+            <MenuItem>2023</MenuItem>
+            <MenuItem>2024</MenuItem>
+            <MenuItem>2025</MenuItem>
+            <MenuItem>2026</MenuItem>
+            <MenuItem>2027</MenuItem>
+            <MenuItem>2028</MenuItem>
+            <MenuItem>2029</MenuItem>
+            <MenuItem>2030</MenuItem>
+            <MenuItem>2031</MenuItem>
+            <MenuItem>2032</MenuItem>
+            <MenuItem>2033</MenuItem>
+            <MenuItem>2034</MenuItem>
+        </MenuList>
+        </Menu>
+        <IconButton
+            variant='outline'
+            colorScheme='blue'
+            color="#6284FF"
+            aria-label='previousMonth'
+            size='lg'
+            fontSize={'3xl'}
+            icon={<IoChevronForwardCircleSharp />}
+        />
   
-      <HStack justify={"left"} p={5}  H={"96%"} width={ "96%"}>
-          <VStack  H={"100%"} width={"60%" } align="top-left" justify={"left"}>
-          <Heading>Task</Heading>
+        </Center>
+  
+        <HStack justify={"left"} p={5}  H={"96%"} width={ "96%"}>
+            <VStack  H={"100%"} width={"60%" } align="top-left" justify={"left"}>
+            <Heading>Tasks</Heading>
   
               <Container bg="#FFFFFF"  minW={"100%"} minH={"700px"} paddingBottom={5} paddingTop={5} >
                   <Card bg="#F5F7F9" Width={"100%"} height={200} maxH={"200px"} p={5} marginBottom={5} overflowY={"auto"}>

--- a/crush-it/src/Homepage/homepage.js
+++ b/crush-it/src/Homepage/homepage.js
@@ -43,19 +43,19 @@ function Homepage(){
         <MenuButton as={Button} variant='outline' colorScheme='blue' ml={1} mr={1} color="#6284FF" size='lg' fontSize={'3xl'} rightIcon={<IoChevronDownCircleOutline />}>
             <Text color="black" p={2} mt={3}>Month</Text>
         </MenuButton>
-        <MenuList maxH="220px" overflowY="auto" w="200px">
-            <MenuItem ml={5} fontSize={'lg'}>January</MenuItem>
-            <MenuItem ml={5} fontSize={'lg'}>February</MenuItem>
-            <MenuItem ml={5} fontSize={'lg'}>March</MenuItem>
-            <MenuItem ml={5} fontSize={'lg'}>April</MenuItem>
-            <MenuItem ml={5} fontSize={'lg'}>May</MenuItem>
-            <MenuItem ml={5} fontSize={'lg'}>June</MenuItem>
-            <MenuItem ml={5} fontSize={'lg'}>July</MenuItem>
-            <MenuItem ml={5} fontSize={'lg'}>August</MenuItem>
-            <MenuItem ml={5} fontSize={'lg'}>September</MenuItem>
-            <MenuItem ml={5} fontSize={'lg'}>October</MenuItem>
-            <MenuItem ml={5} fontSize={'lg'}>November</MenuItem>
-            <MenuItem ml={5} fontSize={'lg'}>December</MenuItem>
+        <MenuList maxH="230px" overflowY="auto" w="100" overflowX="hidden" fontSize={'xl'}>
+            <MenuItem ml={5}>January</MenuItem>
+            <MenuItem ml={5}>February</MenuItem>
+            <MenuItem ml={5}>March</MenuItem>
+            <MenuItem ml={5}>April</MenuItem>
+            <MenuItem ml={5}>May</MenuItem>
+            <MenuItem ml={5}>June</MenuItem>
+            <MenuItem ml={5}>July</MenuItem>
+            <MenuItem ml={5}>August</MenuItem>
+            <MenuItem ml={5}>September</MenuItem>
+            <MenuItem ml={5}>October</MenuItem>
+            <MenuItem ml={5}>November</MenuItem>
+            <MenuItem ml={5}>December</MenuItem>
         </MenuList>
         </Menu>
         <IconButton
@@ -82,38 +82,38 @@ function Homepage(){
         <MenuButton as={Button} variant='outline' colorScheme='blue' ml={1} mr={1} color="#6284FF" size='lg' fontSize={'3xl'} rightIcon={<IoChevronDownCircleOutline />}>
             <Text color="black" p={2} mt={3}>Day</Text>
         </MenuButton>
-        <MenuList>
-            <MenuItem>1</MenuItem>
-            <MenuItem>2</MenuItem>
-            <MenuItem>3</MenuItem>
-            <MenuItem>4</MenuItem>
-            <MenuItem>5</MenuItem>
-            <MenuItem>6</MenuItem>
-            <MenuItem>7</MenuItem>
-            <MenuItem>8</MenuItem>
-            <MenuItem>9</MenuItem>
-            <MenuItem>10</MenuItem>
-            <MenuItem>11</MenuItem>
-            <MenuItem>12</MenuItem>
-            <MenuItem>13</MenuItem>
-            <MenuItem>14</MenuItem>
-            <MenuItem>15</MenuItem>
-            <MenuItem>16</MenuItem>
-            <MenuItem>17</MenuItem>
-            <MenuItem>18</MenuItem>
-            <MenuItem>19</MenuItem>
-            <MenuItem>20</MenuItem>
-            <MenuItem>21</MenuItem>
-            <MenuItem>22</MenuItem>
-            <MenuItem>23</MenuItem>
-            <MenuItem>24</MenuItem>
-            <MenuItem>25</MenuItem>
-            <MenuItem>26</MenuItem>
-            <MenuItem>27</MenuItem>
-            <MenuItem>28</MenuItem>
-            <MenuItem>29</MenuItem>
-            <MenuItem>30</MenuItem>
-            <MenuItem>31</MenuItem>
+        <MenuList maxH="230px" overflowY="auto" w="100" overflowX="hidden" fontSize={'xl'}>
+            <MenuItem ml={5}>1</MenuItem>
+            <MenuItem ml={5}>2</MenuItem>
+            <MenuItem ml={5}>3</MenuItem>
+            <MenuItem ml={5}>4</MenuItem>
+            <MenuItem ml={5}>5</MenuItem>
+            <MenuItem ml={5}>6</MenuItem>
+            <MenuItem ml={5}>7</MenuItem>
+            <MenuItem ml={5}>8</MenuItem>
+            <MenuItem ml={5}>9</MenuItem>
+            <MenuItem ml={5}>10</MenuItem>
+            <MenuItem ml={5}>11</MenuItem>
+            <MenuItem ml={5}>12</MenuItem>
+            <MenuItem ml={5}>13</MenuItem>
+            <MenuItem ml={5}>14</MenuItem>
+            <MenuItem ml={5}>15</MenuItem>
+            <MenuItem ml={5}>16</MenuItem>
+            <MenuItem ml={5}>17</MenuItem>
+            <MenuItem ml={5}>18</MenuItem>
+            <MenuItem ml={5}>19</MenuItem>
+            <MenuItem ml={5}>20</MenuItem>
+            <MenuItem ml={5}>21</MenuItem>
+            <MenuItem ml={5}>22</MenuItem>
+            <MenuItem ml={5}>23</MenuItem>
+            <MenuItem ml={5}>24</MenuItem>
+            <MenuItem ml={5}>25</MenuItem>
+            <MenuItem ml={5}>26</MenuItem>
+            <MenuItem ml={5}>27</MenuItem>
+            <MenuItem ml={5}>28</MenuItem>
+            <MenuItem ml={5}>29</MenuItem>
+            <MenuItem ml={5}>30</MenuItem>
+            <MenuItem ml={5}>31</MenuItem>
         </MenuList>
         </Menu>
         <IconButton
@@ -140,19 +140,19 @@ function Homepage(){
         <MenuButton as={Button} variant='outline' colorScheme='blue' ml={1} mr={1} color="#6284FF" size='lg' fontSize={'3xl'} rightIcon={<IoChevronDownCircleOutline />}>
             <Text color="black" p={2} mt={3}>Year</Text>
         </MenuButton>
-        <MenuList>
-            <MenuItem>2023</MenuItem>
-            <MenuItem>2024</MenuItem>
-            <MenuItem>2025</MenuItem>
-            <MenuItem>2026</MenuItem>
-            <MenuItem>2027</MenuItem>
-            <MenuItem>2028</MenuItem>
-            <MenuItem>2029</MenuItem>
-            <MenuItem>2030</MenuItem>
-            <MenuItem>2031</MenuItem>
-            <MenuItem>2032</MenuItem>
-            <MenuItem>2033</MenuItem>
-            <MenuItem>2034</MenuItem>
+        <MenuList maxH="230px" overflowY="auto" w="100" overflowX="hidden" fontSize={'xl'}>
+            <MenuItem ml={5}>2023</MenuItem>
+            <MenuItem ml={5}>2024</MenuItem>
+            <MenuItem ml={5}>2025</MenuItem>
+            <MenuItem ml={5}>2026</MenuItem>
+            <MenuItem ml={5}>2027</MenuItem>
+            <MenuItem ml={5}>2028</MenuItem>
+            <MenuItem ml={5}>2029</MenuItem>
+            <MenuItem ml={5}>2030</MenuItem>
+            <MenuItem ml={5}>2031</MenuItem>
+            <MenuItem ml={5}>2032</MenuItem>
+            <MenuItem ml={5}>2033</MenuItem>
+            <MenuItem ml={5}>2034</MenuItem>
         </MenuList>
         </Menu>
         <IconButton

--- a/crush-it/src/Homepage/homepage.js
+++ b/crush-it/src/Homepage/homepage.js
@@ -1,6 +1,6 @@
 import React, {useLayoutEffect} from "react";
 import { useNavigate } from "react-router";
-import {Box, Heading, Card, Container, Table, Tbody, TableContainer, Tr, Td, VStack, HStack, Center, IconButton, Button, Text} from '@chakra-ui/react';
+import {Box, Heading, Card, Container, Table, Tbody, TableContainer, Tr, Td, VStack, HStack, Center, IconButton, Button, Text, Flex} from '@chakra-ui/react';
 import {
     Menu,
     MenuButton,
@@ -40,10 +40,30 @@ function Homepage(){
             icon={<IoChevronBackCircleSharp />}
         />
         <Menu>
+        <Flex>
         <MenuButton as={Button} variant='outline' colorScheme='blue' ml={1} mr={1} color="#6284FF" size='lg' fontSize={'3xl'} rightIcon={<IoChevronDownCircleOutline />}>
             <Text color="black" p={2} mt={3}>Month</Text>
         </MenuButton>
-        <MenuList maxH="230px" overflowY="auto" w="100" overflowX="hidden" fontSize={'xl'}>
+        <MenuList maxH="230px" overflowY="auto" w="auto" overflowX="hidden" fontSize={'xl'}
+                css={`
+                &::-webkit-scrollbar {
+                    width: 8px;
+                    height: 80px;
+                  }
+                  &::-webkit-scrollbar-thumb {
+                    background-color: #6284FF;
+                    border-radius: 8px;
+                  }
+                  &::-webkit-scrollbar-track {
+                    background-color: rgba(98, 132, 255, 0.15);
+                  }
+                  &::-webkit-scrollbar-thumb:hover {
+                    background-color: #405DC9;
+                  }
+                  &::-webkit-scrollbar-thumb:active {
+                    background-color: #1E40AF; // Change the color when clicked
+                  }
+        `}>
             <MenuItem ml={5}>January</MenuItem>
             <MenuItem ml={5}>February</MenuItem>
             <MenuItem ml={5}>March</MenuItem>
@@ -57,6 +77,7 @@ function Homepage(){
             <MenuItem ml={5}>November</MenuItem>
             <MenuItem ml={5}>December</MenuItem>
         </MenuList>
+        </Flex>
         </Menu>
         <IconButton
             variant='outline'
@@ -82,7 +103,26 @@ function Homepage(){
         <MenuButton as={Button} variant='outline' colorScheme='blue' ml={1} mr={1} color="#6284FF" size='lg' fontSize={'3xl'} rightIcon={<IoChevronDownCircleOutline />}>
             <Text color="black" p={2} mt={3}>Day</Text>
         </MenuButton>
-        <MenuList maxH="230px" overflowY="auto" w="100" overflowX="hidden" fontSize={'xl'}>
+        <MenuList maxH="230px" overflowY="auto" w="auto" overflowX="hidden" fontSize={'xl'}
+                css={`
+                &::-webkit-scrollbar {
+                    width: 8px;
+                    height: 80px;
+                  }
+                  &::-webkit-scrollbar-thumb {
+                    background-color: #6284FF;
+                    border-radius: 8px;
+                  }
+                  &::-webkit-scrollbar-track {
+                    background-color: rgba(98, 132, 255, 0.15);
+                  }
+                  &::-webkit-scrollbar-thumb:hover {
+                    background-color: #405DC9;
+                  }
+                  &::-webkit-scrollbar-thumb:active {
+                    background-color: #1E40AF; // Change the color when clicked
+                  }
+        `}>
             <MenuItem ml={5}>1</MenuItem>
             <MenuItem ml={5}>2</MenuItem>
             <MenuItem ml={5}>3</MenuItem>
@@ -140,7 +180,26 @@ function Homepage(){
         <MenuButton as={Button} variant='outline' colorScheme='blue' ml={1} mr={1} color="#6284FF" size='lg' fontSize={'3xl'} rightIcon={<IoChevronDownCircleOutline />}>
             <Text color="black" p={2} mt={3}>Year</Text>
         </MenuButton>
-        <MenuList maxH="230px" overflowY="auto" w="100" overflowX="hidden" fontSize={'xl'}>
+        <MenuList maxH="230px" overflowY="auto" w="auto" overflowX="hidden" fontSize={'xl'}
+                css={`
+                &::-webkit-scrollbar {
+                    width: 8px;
+                    height: 80px;
+                  }
+                  &::-webkit-scrollbar-thumb {
+                    background-color: #6284FF;
+                    border-radius: 8px;
+                  }
+                  &::-webkit-scrollbar-track {
+                    background-color: rgba(98, 132, 255, 0.15);
+                  }
+                  &::-webkit-scrollbar-thumb:hover {
+                    background-color: #405DC9;
+                  }
+                  &::-webkit-scrollbar-thumb:active {
+                    background-color: #1E40AF; // Change the color when clicked
+                  }
+        `}>
             <MenuItem ml={5}>2023</MenuItem>
             <MenuItem ml={5}>2024</MenuItem>
             <MenuItem ml={5}>2025</MenuItem>


### PR DESCRIPTION
![image](https://github.com/kauvyap/cs490-project-Birb/assets/83250817/85657159-0016-4acc-a519-0e8be5363590)

- added icon buttons, placeholders for the 3 fields, populated menu items for month/days and years up to 2034

- need to figure out if there is a way to make the menu item look like it is expanding from the menu button (not a priority though)
- **TO DO**
- [ ] add controls so that months with 28/29/30/31 days only have those options in the day calculator
- [ ] implement backend for menu item values
- [ ] replace the placeholders with the current date